### PR TITLE
fix: replace dots with dashes

### DIFF
--- a/.github/workflows/dendron-action.yml
+++ b/.github/workflows/dendron-action.yml
@@ -37,7 +37,14 @@ jobs:
         echo "Changed files:"
         echo "${PAGE_FILES}"
 
-        VAULT_FILES=$(echo "${PAGE_FILES}" | sed -r 's|pages\/(.+?)\/(.+?)\.md|vault\/\1.\2.md|g')
+        VAULT_FILES=$(echo "${PAGE_FILES}" | \
+          sed -r "
+            s/\.md$//;
+            s/\./-/g;
+            s|(.*)/(.*)/(.*)|vault/\2.\3.md|;
+          " 
+        )
+
         echo "::set-output name=FILES::$(echo ${VAULT_FILES} | xargs)"
       env:
         OLD_SHA: ${{ steps.tldr-cached.outputs.SHA }}


### PR DESCRIPTION
Turns out the regex I used was incomplete: Dendron replaces all dots in the file name with dashes. This PR does exactly that - the new sed command first strips the ".md" extension, then replaces all dots with dashes, then does the same name transformation as before, appending the .md extension again.

I let this run for a while in my forked repository and it seems to be working reliably.